### PR TITLE
support OpenCV 3, fix issue with Python 3 division, report source once

### DIFF
--- a/run_webcam.py
+++ b/run_webcam.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+from __future__ import division
+
 import sys
 sys.path.insert(0, 'src')
 import argparse
@@ -40,8 +42,17 @@ def make_triptych(disp_width, frame, style, output):
 	oh, ow, _ = output.shape
 	h = int(ch * disp_width * 0.5 / cw)
 	full_img = np.concatenate([cv2.resize(frame, (int(0.5 * disp_width), h)), cv2.resize(style, (int(0.5 * disp_width), h))], axis=1)
-	full_img = np.concatenate([full_img, cv2.resize(output, (disp_width, disp_width * oh / ow))], axis=0)
+	full_img = np.concatenate([full_img, cv2.resize(output, (disp_width, disp_width * oh // ow))], axis=0)
 	return full_img
+
+
+def get_camera_shape(cam):
+	""" use a different syntax to get video size in OpenCV 2 and OpenCV 3 """
+	cv_version_major, _, _ = cv2.__version__.split('.')
+	if cv_version_major == '3':
+		return cam.get(cv2.CAP_PROP_FRAME_WIDTH), cam.get(cv2.CAP_PROP_FRAME_HEIGHT)
+	else:
+		return cam.get(cv2.cv.CV_CAP_PROP_FRAME_WIDTH), cam.get(cv2.cv.CV_CAP_PROP_FRAME_HEIGHT)
 
 
 def main(width, disp_width, display_source):
@@ -53,14 +64,15 @@ def main(width, disp_width, display_source):
 	with g.as_default(), g.device(device_t), tf.Session(config=soft_config) as sess:	
 		
 		cam = cv2.VideoCapture(0)
-		cam_width, cam_height = cam.get(cv2.cv.CV_CAP_PROP_FRAME_WIDTH), cam.get(cv2.cv.CV_CAP_PROP_FRAME_HEIGHT)
+		cam_width, cam_height = get_camera_shape(cam)
 
 		width = width if width % 4 == 0 else width + 4 - (width % 4) # must be divisible by 4
 		height = int(width * float(cam_height/cam_width))
 		height = height if height % 4 == 0 else height + 4 - (height % 4) # must be divisible by 4
 		img_shape = (height, width, 3)
 		batch_shape = (1,) + img_shape
-		print("batch shape",batch_shape)
+		print("batch shape", batch_shape)
+		print("disp source is ", display_source)
 		img_placeholder = tf.placeholder(tf.float32, shape=batch_shape, name='img_placeholder')
 		preds = transform.net(img_placeholder)
 		
@@ -80,7 +92,6 @@ def main(width, disp_width, display_source):
 			output = output[:, :, :, [2,1,0]].reshape(img_shape)
 			output = np.clip(output, 0, 255).astype(np.uint8)
 			output = cv2.resize(output, (width, height))
-			print("disp source is ",display_source)
 			if display_source:
 				full_img = make_triptych(disp_width, frame, style, output)
 				cv2.imshow('frame', full_img)
@@ -93,7 +104,7 @@ def main(width, disp_width, display_source):
 			if key_ == 27:
 				break
 			elif key_ == ord('a'):
-				idx_model = (idx_model +len(models) - 1) % len(models)
+				idx_model = (idx_model + len(models) - 1) % len(models)
 				print("load %d / %d : %s " % (idx_model, len(models), models[idx_model]))
 				load_checkpoint(models[idx_model]["ckpt"], sess)
 				style = cv2.imread(models[idx_model]["style"])


### PR DESCRIPTION
Added a check on the OpenCV version because a different syntax is needed to access
video properties in OpenCV 2 and 3.
Using Python 3 integer division to compute window size.
The video source argument is printed only once at the start of the script to reduce verbosity.